### PR TITLE
Some modifications

### DIFF
--- a/example.puml
+++ b/example.puml
@@ -6,56 +6,56 @@ skinparam defaultTextAlignment center
 
 ' === Create persons
 ' person( person_id , person_name )
-person(1, "Person 1")
-person(2, "Person 2")
-person(3, "Person 3")
-person(4, "Person 4\n\n01.01.1970 - 01.01.2070")
-person(5, "Person 5")
-person(6, "Person 6")
-person(7, "Person 7")
-person(8, "Person 8")
-person(9, "Person 9")
-person(10, "Person 10")
-person(11, "Person 11")
+person(person1, "Person 1")
+person(person2, "Person 2")
+person(person3, "Person 3")
+person(person4, "Person 4\n\n01.01.1970 - 01.01.2070")
+person(person5, "Person 5")
+person(person6, "Person 6")
+person(person7, "Person 7")
+person(person8, "Person 8")
+person(person9, "Person 9")
+person(person10, "Person 10")
+person(person11, "Person 11")
 
 ' Add persons to the tree using one of following.
 ' - single( person_id )
 '   Add single person
-' - pair( pair_id, first_person_id, second_person_id )
+' - pair( pair_id, first_person_id, second_person_id, union1_style, union2_style )
 '   Add two persons and their marriage
-' - doublepair( first_pair_id, second_pair_id, first_person_id, second_person_id, third_person_id )
+' - doublepair( first_pair_id, second_pair_id, first_person_id, second_person_id, third_person_id, union1_style, union2_style, union3_style, union4_style )
 '   Add three persons and two marriages: first + second and second + third
 ' We can combine persons into generations using `together'
 ' Generation 0
 together {
- single(1)
- single(2)
+ single(person1)
+ single(person2)
 }
 
 ' Generation 1
 together {
- pair(1, 4, 5)
+ pair(pair1, person4, person5, ".left.", "<-right-")
 }
 
 ' Generation 2
 together {
- pair(2, 6, 7)
- single(11)
+ pair(pair2, person6, person7, "-[norank]left-" )
+ single(person11)
 }
 
 ' Generation 3
 together {
- doublepair(3, 4, 10, 8, 9)
+ doublepair(pair3, pair4, person10, person8, person9, $union2_style="-[dotted]left-")
 }
 
 ' Finally, add child information
-' If the person was not added, they will be listed as person_id as "u24"
-' - child( pair_id , person_id )
-' - child( person_id , person_id )
-child(1, 1)
-child(1, 2)
-child(2, 4)
-child(3, 7)
-child(3, 11)
-child(4, 12)
+' If the person was not added, they will be listed as person_id as "uperson12"
+' - child( pair_id , person_id, union_style )
+' - child( person_id , person_id, union_style )
+child(pair1, person1, "-[dashed,thickness=10]down-")
+child(pair1, person2)
+child(pair2, person4)
+child(pair3, person7)
+child(pair3, person11)
+child(pair4, person12)
 @enduml

--- a/genealogy.iuml
+++ b/genealogy.iuml
@@ -6,7 +6,7 @@
 !return "b" + $id
 !endfunction
 
-!procedure person($id, $name)
+!unquoted procedure person($id, $name)
 %set_variable_value(getuid($id), $name)
 !endprocedure
 
@@ -15,34 +15,34 @@
 !return $name + '"'
 !endfunction
 
-!procedure single($uid)
+!unquoted procedure single($uid)
  rectangle getname($uid) as getuid($uid)
 !endprocedure 
 
-!procedure pair($id, $uid1, $uid2)
+!unquoted procedure pair($id, $uid1, $uid2, $union1_style="-left-", , $union2_style="-right-")
  together {
   single($uid1)
   interface " " as getbid($id)
   single($uid2)
-  getuid($uid1) -left- getbid($id)
-  getuid($uid2) -right- getbid($id)
+  getuid($uid1) $union1_style getbid($id)
+  getuid($uid2) $union2_style getbid($id)
  }
 !endprocedure 
 
-!procedure doublepair($id1, $id2, $uid3, $uid2, $uid1)
+!unquoted procedure doublepair($id1, $id2, $uid3, $uid2, $uid1, $union1_style="-right-", $union2_style="-left-", $union3_style="-left-", $union4_style="-right-")
  together {
   single($uid1)
   interface " " as getbid($id1)
   single($uid2)
   interface " " as getbid($id2)
   single($uid3)
-  getuid($uid1) -right- getbid($id1)
-  getuid($uid2) -left- getbid($id1)
-  getuid($uid3) -left- getbid($id2)
-  getuid($uid2) -right- getbid($id2)
+  getuid($uid1) $union1_style getbid($id1)
+  getuid($uid2) $union2_style getbid($id1)
+  getuid($uid3) $union3_style getbid($id2)
+  getuid($uid2) $union4_style getbid($id2)
  }
 !endprocedure 
 
-!procedure child($bid, $uid)
-getbid($bid) -down- getuid($uid)
+!unquoted procedure child($bid, $uid, $union_style="-down-")
+getbid($bid) $union_style getuid($uid)
 !endprocedure


### PR DESCRIPTION
I've been making adjustments to solve some of the points mentioned in #1.

Now the quoted strings are optional when passing parameters to the procedures, in that way, strings can be used as identifiers, making them differentiate easily from normal strings (resolve point 1 in #1).

Another change that I made was to customize the style and orientation of the arrows in the `pair()`, `doublepair()` and `child()` procedures with extra parameters (solves point 5 in #1),  which is quite useful to have a more detailed control in that aspect, and may also solve that problem with the parental bond between parent/child. I imagine that with rectangles you can do the same using `skinparam` or the `<style>` tag but I haven't checked.

Finally I also updated example.puml making the identifiers less ambiguous (solving point 2 in #1) and add some examples of custom arrows. This is how the diagram looks like with these changes:
![Family tree with changes in code](https://user-images.githubusercontent.com/20852424/128618327-2c632319-7212-4872-8d74-0a1bf2c60813.png)
